### PR TITLE
修复结构体内部，内嵌同类指针时出现的类型错误

### DIFF
--- a/parser.cc
+++ b/parser.cc
@@ -264,6 +264,7 @@ std::shared_ptr<CType> Parser::ParseStructOrUnionSpec() {
             name = llvm::StringRef(tag.ptr, tag.len);
         }
         recordTy = std::make_shared<CRecordType>(name, std::vector<Member>(), tagKind);
+        sema.SemaTagDecl(tag, recordTy);
     }
 
     /*
@@ -290,7 +291,7 @@ std::shared_ptr<CType> Parser::ParseStructOrUnionSpec() {
         CRecordType *ty = llvm::dyn_cast<CRecordType>(recordTy.get());
         ty->SetMembers(members);
 
-        return sema.SemaTagDecl(tag, recordTy);
+        return recordTy;
     }else {
        return recordTy;  
     }


### PR DESCRIPTION
经过修复之后，以下的代码可以在编译器中被正确编译和执行：

```C
struct A {
    int a;
    struct A *p;
};

int main() {
    struct A v1 = { 1991 };
    struct A v2 = { 2025 };
    v1.p = &v2;

    return v1.p->a;
}
```